### PR TITLE
Improve newline filtering

### DIFF
--- a/config/evaluation/arnebab.yml
+++ b/config/evaluation/arnebab.yml
@@ -444,8 +444,9 @@ metrics:
       exclude_rows: [3]
 
 ngram_mapper:
-  # Exclude any ngram in which "\n" is contained as not the last symbol
-  # This encodes a mental pause that usually comes with hitting the "Enter" key
+  # Exclude ngrams that contain a line break, followed by a non-line-break character.
+  # This encodes a mental pause which usually comes after hitting the "Enter" key, before
+  # continuing to write.
   exclude_line_breaks: false
 
   # Split symbols belonging to higher layers of the layout into combinations involving modifiers

--- a/config/evaluation/default.yml
+++ b/config/evaluation/default.yml
@@ -455,8 +455,9 @@ metrics:
       exclude_rows: [3]
 
 ngram_mapper:
-  # Exclude any ngram in which "\n" is contained as not the last symbol
-  # This encodes a mental pause that usually comes with hitting the "Enter" key
+  # Exclude ngrams that contain a line break, followed by a non-line-break character.
+  # This encodes a mental pause which usually comes after hitting the "Enter" key, before
+  # continuing to write.
   exclude_line_breaks: true
 
   # Split symbols belonging to higher layers of the layout into combinations involving modifiers

--- a/layout_evaluation/src/ngram_mapper/bigram_mapper.rs
+++ b/layout_evaluation/src/ngram_mapper/bigram_mapper.rs
@@ -151,7 +151,7 @@ fn layerkey_indices(
         .grams
         .iter()
         //.filter(|((c1, c2), _weight)| !c1.is_whitespace() && !c2.is_whitespace())
-        .filter(|((c1, _c2), _weight)| !exclude_line_breaks || *c1 != '\n')
+        .filter(|((c1, c2), _weight)| !(exclude_line_breaks && *c1 == '\n' && *c2 != '\n'))
         .for_each(|((c1, c2), weight)| {
             let layerkey1 = match layout.get_layerkey_index_for_symbol(c1) {
                 Some(k) => k,

--- a/layout_evaluation/src/ngram_mapper/on_demand_ngram_mapper.rs
+++ b/layout_evaluation/src/ngram_mapper/on_demand_ngram_mapper.rs
@@ -33,7 +33,7 @@ pub struct NgramMapperConfig {
     pub secondary_bigrams_from_trigrams: SecondaryBigramsFromTrigramsConfig,
     /// Parameters for the increase in weight of common bigrams (with already high frequency).
     pub increase_common_bigrams: IncreaseCommonBigramsConfig,
-    /// Exclude line breaks in the beginning of bigrams and trigrams
+    /// Exclude ngrams that contain a line break, followed by a non-line-break character
     pub exclude_line_breaks: bool,
 }
 

--- a/layout_evaluation/src/ngram_mapper/trigram_mapper.rs
+++ b/layout_evaluation/src/ngram_mapper/trigram_mapper.rs
@@ -22,7 +22,10 @@ fn mapped_trigrams(
         //.filter(|((c1, c2, c3), _weight)| {
         //    !c1.is_whitespace() && !c2.is_whitespace() && !c3.is_whitespace()
         //})
-        .filter(|((c1, c2, _c3), _weight)| !exclude_line_breaks || (*c1 != '\n' && *c2 != '\n'))
+        .filter(|((c1, c2, c3), _weight)| {
+            // Exclude trigrams that contain a line break, followed by a non-line-break character
+            !(exclude_line_breaks && ((*c1 == '\n' && *c2 != '\n') || (*c2 == '\n' && *c3 != '\n')))
+        })
         .for_each(|((c1, c2, c3), weight)| {
             let key1 = match layout.get_layerkey_index_for_symbol(c1) {
                 Some(k) => k,


### PR DESCRIPTION
Same idea as the ["." / "," pull request](https://github.com/dariogoetz/keyboard_layout_optimizer/pull/25).

We only want to filter n-grams that envelop a pause, keeping the ones, that contain a pause but do not follow up with letters after that.

The previous implementation was almost perfect. The only issue I fixed in this PR is that patterns like "`\n \n \n`" or "`{letter} \n \n`" used to get filtered and now don't, because they don't contain anything after the beginning of the pause.

I also updated some comments.