### PR TITLE
Fix use of `position` in `no_handswitch_after_unbalancing_key`

### DIFF
--- a/layout_evaluation/src/metrics/bigram_metrics/no_handswitch_after_unbalancing_key.rs
+++ b/layout_evaluation/src/metrics/bigram_metrics/no_handswitch_after_unbalancing_key.rs
@@ -59,9 +59,10 @@ impl BigramMetric for NoHandSwitchAfterUnbalancingKey {
 
         // if the other key is unbalancing too and on the other side of the hand, put extra cost on it depending on their distance
         let unb2 = k2.key.unbalancing;
-        let dx = k1.key.matrix_position.0.abs_diff(k2.key.matrix_position.0) as f64;
-        let dy = k1.key.matrix_position.1.abs_diff(k2.key.matrix_position.1) as f64;
-        if unb2 > 0.0 && dx > 3.0 {
+        let is_spaced_apart = k1.key.matrix_position.0.abs_diff(k2.key.matrix_position.0) > 3;
+        let dx = (k1.key.position.0 - k2.key.position.0).abs(); // Vertical distance
+        let dy = (k1.key.position.1 - k2.key.position.1).abs(); // Horizontal distance
+        if unb2 > 0.0 && is_spaced_apart {
             // second key is also unbalancing -> extra cost
             cost += unb1 * unb2 * self.unbalancing_after_unbalancing * (dx + dy - 3.0);
         };


### PR DESCRIPTION
Here we assign a cost according to how far keys are located away from each other. However, in the previous implementation, the `matrix_position` was actually used instead of the real distance (=`position). This PR fixes this issue.

---

Slightly off-topic:
1. This might be the place where the `distance` functions may have been useful. However, I wouldn't know where to apply them anyway, as there are two different calculations going on: `(dx + dy - 3.0)` and `1.0 + dy * dy`.
2. Why do we `exclude_rows: [3]` in **`movement_pattern_same_row`** and **`trigram_rolls`**?