### PR TITLE
Fix issue 90

### DIFF
--- a/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
+++ b/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
@@ -5,6 +5,13 @@
 //!
 //! *Note:* ArneBab's irregularity does not include all bigram metrics (asymmetric bigrams is missing).
 
+// Const is related to workaround for issue #90. Note that the exact value of total_weight
+// slightly changed with each run before this workaround (due to float precisision?).
+// Therefore by fixing this constant for normalizing the total_weight, the behaviour
+// is not 100% identical compared to before. However the impact to behaviour and
+// total_cost is neglectable.
+const DEFAULT_NGRAM_TOTAL_WEIGHT: f64 = 163697606.220464646816253662109375;
+
 use super::TrigramMetric;
 use crate::metrics::bigram_metrics::BigramMetric;
 use crate::results::NormalizationType;
@@ -47,17 +54,26 @@ impl TrigramMetric for Irregularity {
         total_weight: f64,
         layout: &Layout,
     ) -> Option<f64> {
+        // Workaround for issue #90 (see https://github.com/dariogoetz/keyboard_layout_optimizer/issues/90)
+        // Current irregularity implementation is sensitive to ngram total_weight, that means
+        // ngram normalization leads to different calculated cost. Most likely due to
+        // taking the sqrt of a sum.
+        // To not break Webapp - Result Exploration, ngrams are therefore normalized to total_weight
+        // of the default ngrams deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm
+        let total_weight_normalized = DEFAULT_NGRAM_TOTAL_WEIGHT;
+        let weight_normalized = weight / total_weight * DEFAULT_NGRAM_TOTAL_WEIGHT;
+
         let costs: (f64, f64) = self
             .bigram_metrics
             .iter()
             .map(|(metric_weight, _, metric)| {
                 let cost1 = metric_weight
                     * metric
-                        .individual_cost(k1, k2, weight, total_weight, layout)
+                        .individual_cost(k1, k2, weight_normalized, total_weight_normalized, layout)
                         .unwrap_or(0.0);
                 let cost2 = metric_weight
                     * metric
-                        .individual_cost(k2, k3, weight, total_weight, layout)
+                        .individual_cost(k2, k3, weight_normalized, total_weight_normalized, layout)
                         .unwrap_or(0.0);
 
                 (cost1, cost2)
@@ -65,7 +81,11 @@ impl TrigramMetric for Irregularity {
             .fold((0.0, 0.0), |(acc1, acc2), (c1, c2)| (acc1 + c1, acc2 + c2));
 
         let cost = (1.0 + costs.0) * (1.0 + costs.1) - 1.0;
-        Some(cost.max(0.0))
+        Some(
+            cost.max(0.0) * total_weight * total_weight
+                / DEFAULT_NGRAM_TOTAL_WEIGHT
+                / DEFAULT_NGRAM_TOTAL_WEIGHT,
+        )
     }
 
     fn total_cost(

--- a/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
+++ b/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
@@ -5,11 +5,8 @@
 //!
 //! *Note:* ArneBab's irregularity does not include all bigram metrics (asymmetric bigrams is missing).
 
-// Const is related to workaround for issue #90. Note that the exact value of total_weight
-// slightly changed with each run before this workaround (due to float precisision?).
-// Therefore by fixing this constant for normalizing the total_weight, the behaviour
-// is not 100% identical compared to before. However the impact to behaviour and
-// total_cost is neglectable.
+// Related to workaround (issue #90)
+// total_weight 2-grams of deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm
 const DEFAULT_NGRAM_TOTAL_WEIGHT: f64 = 163697606.220464646816253662109375;
 
 use super::TrigramMetric;
@@ -55,11 +52,11 @@ impl TrigramMetric for Irregularity {
         layout: &Layout,
     ) -> Option<f64> {
         // Workaround for issue #90 (see https://github.com/dariogoetz/keyboard_layout_optimizer/issues/90)
-        // Current irregularity implementation is sensitive to ngram total_weight, that means
+        // Current irregularity implementation is affected by 2-grams total_weight, that means
         // ngram normalization leads to different calculated cost. Most likely due to
         // taking the sqrt of a sum.
-        // To not break Webapp - Result Exploration, ngrams are therefore normalized to total_weight
-        // of the default ngrams deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm
+        // 2-grams are therefore normalized to the total_weight of the default ngrams
+        // deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm
         let normalization_factor = DEFAULT_NGRAM_TOTAL_WEIGHT / total_weight;
         let weight_normalized = weight * normalization_factor;
 

--- a/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
+++ b/layout_evaluation/src/metrics/trigram_metrics/irregularity.rs
@@ -60,8 +60,8 @@ impl TrigramMetric for Irregularity {
         // taking the sqrt of a sum.
         // To not break Webapp - Result Exploration, ngrams are therefore normalized to total_weight
         // of the default ngrams deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm
-        let total_weight_normalized = DEFAULT_NGRAM_TOTAL_WEIGHT;
-        let weight_normalized = weight / total_weight * DEFAULT_NGRAM_TOTAL_WEIGHT;
+        let normalization_factor = DEFAULT_NGRAM_TOTAL_WEIGHT / total_weight;
+        let weight_normalized = weight * normalization_factor;
 
         let costs: (f64, f64) = self
             .bigram_metrics
@@ -69,11 +69,23 @@ impl TrigramMetric for Irregularity {
             .map(|(metric_weight, _, metric)| {
                 let cost1 = metric_weight
                     * metric
-                        .individual_cost(k1, k2, weight_normalized, total_weight_normalized, layout)
+                        .individual_cost(
+                            k1,
+                            k2,
+                            weight_normalized,
+                            DEFAULT_NGRAM_TOTAL_WEIGHT,
+                            layout,
+                        )
                         .unwrap_or(0.0);
                 let cost2 = metric_weight
                     * metric
-                        .individual_cost(k2, k3, weight_normalized, total_weight_normalized, layout)
+                        .individual_cost(
+                            k2,
+                            k3,
+                            weight_normalized,
+                            DEFAULT_NGRAM_TOTAL_WEIGHT,
+                            layout,
+                        )
                         .unwrap_or(0.0);
 
                 (cost1, cost2)
@@ -81,11 +93,7 @@ impl TrigramMetric for Irregularity {
             .fold((0.0, 0.0), |(acc1, acc2), (c1, c2)| (acc1 + c1, acc2 + c2));
 
         let cost = (1.0 + costs.0) * (1.0 + costs.1) - 1.0;
-        Some(
-            cost.max(0.0) * total_weight * total_weight
-                / DEFAULT_NGRAM_TOTAL_WEIGHT
-                / DEFAULT_NGRAM_TOTAL_WEIGHT,
-        )
+        Some(cost.max(0.0) / normalization_factor / normalization_factor)
     }
 
     fn total_cost(


### PR DESCRIPTION
This should fix #90, while preserving the reported irregularity cost (at least for two decimal places).

Irregulary Cost for `zyuaqpbmlfjßcsieodtnrhvxüäöwg,.k` compared:

ngrams | Irregulary Cost Baseline | Irregulary Cost Fix #90
-- | -- | --
arne | 34,74 | 34,74
arne_basis | 7,27 | 7,27
arne_no_special | 34,91 | 34,91
arne_norm* | 37,89 | 34,74
code_actionScript | 143,94 | 143,94
deu_mixed_0.6_eng_news_typical_0.4 | 16,52 | 16,52
deu_mixed_1m | 19,22 | 19,22
deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4 | 11,17 | 11,17
deu_mixed_wiki_web_0.6_eng_news_typical_wiki_web_0.4_norm* | 16,93 | 11,17
deu_web_0.6_eng_web_0.4 | 9,33 | 9,33
deu_web_1m | 12,17 | 12,17
deu_wiki_0.6_eng_wiki_0.4 | 8,81 | 8,81
deu_wiki_1m | 11,06 | 11,06
eng_news_typical_1m | 18,04 | 18,04
eng_shai | 8,61 | 8,61
eng_web_1m | 8,79 | 8,79
eng_wiki_1m | 7,06 | 7,06
irc_neo | 13,8 | 13,8
oxey_english | 106,07 | 8,5
oxey_english2 | panicked |  
oxey_german | panicked |  

I would have expected, that there are differences visible for the ngrams, because the total_weights are different compared to the chosen default one (in #90). However, it seems #90 is only sensitive to big differences. Maybe for more visible decimal places there would be changes visible (haven't tested this).