### PR TITLE
Replace hardcoded set of characters when a starting layout is not specified with a set from the layout file

### DIFF
--- a/keyboard_layout/src/grouped_layout_generator.rs
+++ b/keyboard_layout/src/grouped_layout_generator.rs
@@ -183,4 +183,26 @@ impl LayoutGenerator for GroupedLayoutGenerator {
 
         self.generate_unchecked(layout_keys)
     }
+
+    fn base_layout_string(&self) -> String {
+        let n_fixed = self.fixed_keys.iter().filter(|fixed| !**fixed).count();
+        if n_fixed == 0 {
+            return String::new();
+        }
+        let total_chars = self.permutable_key_map.len();
+        let n_iter = total_chars / n_fixed;
+        
+        let mut result = String::with_capacity(total_chars);
+        for iter in 0..n_iter {
+            for (key_layers, fixed) in self.base_layout_symbols.iter().zip(self.fixed_keys.iter()) {
+                if !*fixed {
+                    let layer_idx = iter * (self.grouped_layers as usize);
+                    if let Some(c) = key_layers.get(layer_idx) {
+                        result.push(*c);
+                    }
+                }
+            }
+        }
+        result
+    }
 }

--- a/keyboard_layout/src/layout_generator.rs
+++ b/keyboard_layout/src/layout_generator.rs
@@ -8,6 +8,9 @@ use anyhow::Result;
 
 pub trait LayoutGenerator: Send + Sync + LayoutGeneratorClone + fmt::Debug {
     fn generate(&self, layout_keys: &str) -> Result<Layout>;
+    
+    /// Returns the default string representation of the base layout (only non-fixed keys).
+    fn base_layout_string(&self) -> String;
 }
 
 impl Clone for Box<dyn LayoutGenerator> {

--- a/keyboard_layout/src/neo_layout_generator.rs
+++ b/keyboard_layout/src/neo_layout_generator.rs
@@ -207,4 +207,13 @@ impl LayoutGenerator for NeoLayoutGenerator {
 
         self.generate_unchecked(layout_keys)
     }
+
+    fn base_layout_string(&self) -> String {
+        self.base_layout_symbols
+            .iter()
+            .zip(self.fixed_keys.iter())
+            .filter(|(_key_layers, fixed)| !**fixed)
+            .filter_map(|(key_layers, _)| key_layers.first())
+            .collect()
+    }
 }

--- a/keyboard_layout_optimizer/src/bin/optimize_genetic.rs
+++ b/keyboard_layout_optimizer/src/bin/optimize_genetic.rs
@@ -17,8 +17,8 @@ struct Options {
     fix: Option<String>,
 
     /// Fix the keys from this layout (will be overwritten by --start-layout)
-    #[clap(long, default_value = "xvlcwkhgfqyßuiaeosnrtdüöäpzbm,.j")]
-    fix_from: String,
+    #[clap(long)]
+    fix_from: Option<String>,
 
     /// Filename of optimization configuration file
     #[clap(short, long, default_value = "config/optimization/genetic.yml")]
@@ -76,12 +76,6 @@ fn main() {
 
     let options = Options::parse();
 
-    let fix_from: String = options
-        .fix_from
-        .chars()
-        .filter(|c| options.do_not_remove_whitespace || !c.is_whitespace())
-        .collect();
-
     let start_layout = options.start_layout.as_ref().map(|s| {
         s.chars()
             .filter(|c| options.do_not_remove_whitespace || !c.is_whitespace())
@@ -89,6 +83,13 @@ fn main() {
     });
 
     let (layout_generator, evaluator) = common::init(&options.evaluation_parameters);
+
+    let fix_from_str = options.fix_from.clone().unwrap_or_else(|| layout_generator.base_layout_string());
+
+    let fix_from_parsed: String = fix_from_str
+        .chars()
+        .filter(|c| options.do_not_remove_whitespace || !c.is_whitespace())
+        .collect();
 
     let mut optimization_params = optimization::Parameters::from_yaml(
         &options.optimization_parameters,
@@ -104,7 +105,7 @@ fn main() {
         optimization_params.generation_limit = generation_limit
     }
 
-    let fix_from = start_layout.as_ref().unwrap_or(&fix_from).to_string();
+    let fix_from = start_layout.clone().unwrap_or(fix_from_parsed);
 
     loop {
         let (layout_str, layout) = optimization::optimize(

--- a/keyboard_layout_optimizer/src/bin/optimize_sa.rs
+++ b/keyboard_layout_optimizer/src/bin/optimize_sa.rs
@@ -19,8 +19,8 @@ struct Options {
     fix: Option<String>,
 
     /// Fix the keys from this layout (will be overwritten by --start-layout)
-    #[clap(long, default_value = "xvlcwkhgfqßuiaeosnrtdyüöäpzbm,.j")]
-    fix_from: String,
+    #[clap(long)]
+    fix_from: Option<String>,
 
     /// Filename of optimization configuration file
     #[clap(short, long, default_value = "config/optimization/sa.yml")]
@@ -129,12 +129,6 @@ fn main() {
 
     let options = Options::parse();
 
-    let fix_from: String = options
-        .fix_from
-        .chars()
-        .filter(|c| options.do_not_remove_whitespace || !c.is_whitespace())
-        .collect();
-
     let start_layouts: Vec<String> = options
         .start_layouts
         .iter()
@@ -146,6 +140,14 @@ fn main() {
         .collect();
 
     let (layout_generator, evaluator) = common::init(&options.evaluation_parameters);
+
+    let fix_from_str = options.fix_from.clone().unwrap_or_else(|| layout_generator.base_layout_string());
+    let fix_from: String = fix_from_str
+        .chars()
+        .filter(|c| options.do_not_remove_whitespace || !c.is_whitespace())
+        .collect();
+
+
 
     let mut optimization_params = optimization::Parameters::from_yaml(
         &options.optimization_parameters,

--- a/keyboard_layout_optimizer/src/bin/random_evaluate.rs
+++ b/keyboard_layout_optimizer/src/bin/random_evaluate.rs
@@ -21,7 +21,7 @@ fn main() {
 
     let (layout_generator, evaluator) = common::init(&options.evaluation_parameters);
 
-    let layout_str = "abcdefghijklmnopqrstuvwxyzäöüß,.";
+    let layout_str = layout_generator.base_layout_string();
     let mut best_cost: Option<f64> = None;
     let mut best_layout: String = "".into();
 


### PR DESCRIPTION
If -s is not specified for the optimize_ commands, the algorithm starts with the hardcoded "xvlcwkhgfqyßuiaeosnrtdüöäpzbm,.j". If the layout config has a different set of characters, it instantly fails. This change fixes the issue by taking characters from the layout file instead.